### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,16 +16,16 @@ analogWrite	KEYWORD2
 analogReadMode	KEYWORD2
 analogWriteMode	KEYWORD2
 digitalMode	KEYWORD2
-digitalWrite	KEYWORD2	
-digitalRead     KEYWORD2
+digitalWrite	KEYWORD2
+digitalRead	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
 mA	LITERAL1
 V10	LITERAL1
-V5  LITERAL1
-mA_p  LITERAL1
-V10_p  LITERAL1
-V5_p  LITERAL1
-mA_raw   LITERAL1
-V10_raw  LITERAL1
+V5	LITERAL1
+mA_p	LITERAL1
+V10_p	LITERAL1
+V5_p	LITERAL1
+mA_raw	LITERAL1
+V10_raw	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords